### PR TITLE
fix: typo and clarity changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,31 +333,10 @@ Waveforms (such as VCD) let you trace signals (fetch/decode/execute stages, regi
 
 We will look more at waveforms later.
 
-# Known Problems
+# Known Problems and Next Steps (WIP)
 
-Please let us know if you run into issues, any steps to debug them, and solutions! 
+Please refer to the issues page of this repo for action items and ways to contribute! If you find any bugs/solutions/new features, feel free to take on anything or add to the list.
 
-* sodor uses a custom reset -- by writing to 0x44
-   * https://github.com/riscv-software-src/riscv-isa-sim/blob/90a04da3f9235e17ab456b9263080f2dc32e4f1e/fesvr/dtm.cc 
-   * this should get updated so that sodor supports resuming execution from `0x7b1` (dpc) [spec compliant] after coming out of debug mode.
-
-
-* cannot build riscv bmark test in rv32 due to ucb-bar riscv toolchain (feedstock) not supporting multi-lib - https://github.com/ucb-bar/riscv-tools-feedstock/pull/8 and the lack of a rv32 toolchain thats been compiled from source (cs152 has one, but ideally we don't depend on that, and we build from scratch)
-
-
-* when run it creates a bunch of "rv32_2stage", "rv32_1stage" etc folders in `${forge}/generators/riscv-sodor/rv32_1stage`.. these shouldnt be made, its done somewhere in the makefile
-
-# Next Steps (WIP)
-
-We will release more instructions, but as this is a collaborative effort, we're very transparent about the directions as we define them, and welcome your own tackling of these and other problems! 
-
-Things that need to be done before tapeout:
-
-* jtag TAP to DMI unit - https://chipyard.readthedocs.io/en/stable/Advanced-Concepts/Chip-Communication.html
-* replace 3 stage's 1 cycle mem w/ srams
-* IO
-* bump to chisel 3, java 17 or smth, not java 8 (1.8.0), bump scala version from 2.12 to latest CY version
-* whats the modern version of chisel-iotesters? move to that
-* figure out the custom reset/custom fesvr (to write to 0x44 to start exec) situation, and whether its even viable to keep that around?? (will we successfully bringup if its like that)
+More instructions will be released later on, but as this is a collaborative effort, we're very transparent about the directions as we define them, and welcome your own tackling of these and other problems!
 
 We would like to also establish the foundation: you learn where the RTL comes from (Chisel elaboration), how the pipeline and memory/CSR interfaces are structured, and how to correlate the design with the generated SystemVerilog. Without that familiarity, debugging the RTL, integrating peripherals, and interpreting PD/simulation results would be much harder. Treat this as the “get to know the core" step before verification and tapeout.


### PR DESCRIPTION
fixed typos, moved mandatory setup commands from links directly into readme, removed redundant cloning instructions (our fesvr repo is already submoduled)